### PR TITLE
Decrease chance of becoming default hale

### DIFF
--- a/addons/sourcemod/scripting/vsh/nextboss.sp
+++ b/addons/sourcemod/scripting/vsh/nextboss.sp
@@ -7,7 +7,7 @@ void NextBoss_Init()
 	g_aNextBoss = new ArrayList(sizeof(NextBoss));
 	g_aNextBossMulti = new ArrayList();
 	
-	g_ConfigConvar.Create("vsh_boss_chance_saxton", "0.25", "% chance for next boss to be Saxton Hale from normal bosses pool (0.0 - 1.0)", _, true, 0.0, true, 1.0);
+	g_ConfigConvar.Create("vsh_boss_chance_saxton", "0.15", "% chance for next boss to be Saxton Hale from normal bosses pool (0.0 - 1.0)", _, true, 0.0, true, 1.0);
 	g_ConfigConvar.Create("vsh_boss_chance_multi", "0.20", "% chance for next boss to be multiple bosses (0.0 - 1.0)", _, true, 0.0, true, 1.0);
 	g_ConfigConvar.Create("vsh_boss_chance_modifiers", "0.15", "% chance for next boss to have random modifiers (0.0 - 1.0)", _, true, 0.0, true, 1.0);
 }


### PR DESCRIPTION
There are 11 other solo bosses (excluding The Last Yeti and Merasmus) with, to be frank, more interesting kits than the default hale. While he may be the "face" of VSH, there are many players who enjoy playing as/against the "special" hales instead, and the smaller amount who are tired of playing as/against him.

If my math is right, he should now have just under double the chance of other bosses to picked, rather than the more-than-triple chance he has currently.

New formula: 100 - 15% chance of being hale = 85% chance for other bosses (excluding duo-bosses.) 85 / 11 = 7.7% chance for each boss other than hale.

Old formula: 100 - 25% chance of being hale = 75% chance for other bosses (excluding duo-bosses) 75/ 11 = 6.8% chance for each boss other than hale.

